### PR TITLE
fix(ci): correct `typecheck` and `inclusive-naming` jobs 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,12 +24,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install `just`
-        run: sudo snap install just --classic
-      - name: Install `woke`
-        run: sudo snap install woke
       - name: Run inclusive naming checks
-        run: just woke
+        uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: true
 
   lint:
     name: Lint checks

--- a/src/apptainer.py
+++ b/src/apptainer.py
@@ -17,6 +17,7 @@
 import logging
 import shutil
 import subprocess
+from string import Template
 
 import charms.operator_libs_linux.v0.apt as apt
 import distro
@@ -108,13 +109,14 @@ def version() -> str:
     Raises:
         ApptainerOpsError: Raised if `apptainer` is not installed on unit.
     """
+    error_msg = Template("failed to get the version of `apptainer` installed. reason: $reason")
     try:
         result = subprocess.check_output(["apptainer", "--version"], text=True)
         return result.split()[-1]
-    except (FileNotFoundError, subprocess.CalledProcessError) as e:
-        raise ApptainerOpsError(
-            f"failed to get the version of `apptainer` installed. reason: {e.stderr}"
-        )
+    except FileNotFoundError as e:
+        raise ApptainerOpsError(error_msg.substitute(reason=str(e).lower()))
+    except subprocess.CalledProcessError as e:
+        raise ApptainerOpsError(error_msg.substitute(reason=(str(e) + f" {e.stderr}").lower()))
 
 
 def installed() -> bool:


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

This PR fixes the failing apptainer CI jobs `typecheck` and `inclusive-naming`.

To fix the `typecheck` job I needed to modify how the `version()` function in the _apptainer.py_ module handled both the `FileNotFoundError` and `subprocess.CalledProcessError` exceptions to be more granular. To fix the `inclusive-naming` job, I switched from using the justfile to the `woke` GitHub Actions workflow. This way we don't need to install `uv` as a wasted dependency since `woke` is a Go binary.

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Failing CI jobs.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

These CI fixes are a non-user facing change.