### PR TITLE
feat: add tf module for the apptainer operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ version
 cover/
 requirements.txt
 *.secret
+
+# Terraform
+.terraform
+.terraform.lock.hcl
+*.tfstate*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,63 @@
+# Terraform module for apptainer
+
+This is a Terraform module facilitating the deployment of the apptainer charm using
+the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju).
+For more information, refer to the
+[documentation](https://registry.terraform.io/providers/juju/juju/latest/docs)
+for the Juju Terraform provider.
+
+## Requirements
+
+- Terraform >= 1.0
+- Juju Terraform provider ~> 1.0
+- An existing Juju model
+
+## API
+
+### Inputs
+
+| Name         | Type        | Description                                                        | Default         | Required |
+|--------------|-------------|--------------------------------------------------------------------|-----------------|:--------:|
+| `app_name`   | string      | The Juju application name                                          | `"apptainer"`   |          |
+| `channel`    | string      | Charm channel to deploy from                                       | `"latest/beta"` |          |
+| `config`     | map(string) | Map of charm configuration options                                 | `{}`            |          |
+| `model_uuid` | string      | UUID of the Juju model to deploy the charm into                    |                 |    Y     |
+| `revision`   | number      | Charm revision to deploy. Null deploys the latest on given channel | `null`          |          |
+
+### Outputs
+
+| Name          | Description                              |
+|---------------|------------------------------------------|
+| `application` | The deployed `juju_application` resource |
+| `provides`    | Map of `provides` endpoint names         |
+| `requires`    | Map of `requires` endpoint names         |
+
+The `provides` output exposes the following endpoint names:
+
+| Key           | Endpoint name |
+|---------------|---------------|
+| `oci_runtime` | `oci-runtime` |
+
+The `requires` output exposes the following endpoint names:
+
+| Key         | Endpoint name |
+|-------------|---------------|
+| `juju_info` | `juju-info`   |
+
+## Usage
+
+Ensure that Terraform is aware of the Juju model dependency of the charm module.
+
+```hcl
+module "apptainer" {
+  source     = "git::https://github.com/charmed-hpc/apptainer-operator//terraform"
+  model_uuid = juju_model.my_model.uuid
+}
+```
+
+To deploy this module with its required dependency, you can run the following
+command:
+
+```shell
+terraform apply -var="model_uuid=<MODEL_UUID>" -auto-approve
+```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,27 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "juju_application" "apptainer" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "apptainer"
+    base     = var.base
+    channel  = var.channel
+    revision = var.revision
+  }
+
+  config = var.config
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,32 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "application" {
+  description = "The deployed juju_application resource"
+  value       = juju_application.apptainer
+}
+
+output "provides" {
+  description = "Map of provides endpoint names"
+  value = {
+    oci_runtime = "oci-runtime"
+  }
+}
+
+output "requires" {
+  description = "Map of requires endpoint names"
+  value = {
+    juju_info = "juju-info"
+  }
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,15 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+provider "juju" {}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,24 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,49 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "app_name" {
+  description = "The Juju application name"
+  type        = string
+  default     = "apptainer"
+}
+
+variable "base" {
+  description = "Operating system base to use for the deployed application (for example, ubuntu@24.04)"
+  type        = string
+  default     = null
+}
+
+variable "channel" {
+  description = "Charm channel to deploy from"
+  type        = string
+  default     = "latest/beta"
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_uuid" {
+  description = "UUID of the Juju model to deploy the charm into"
+  type        = string
+  nullable    = false
+}
+
+variable "revision" {
+  description = "Charm revision to deploy. Null deploys the latest on the given channel"
+  type        = number
+  default     = null
+}


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds a Terraform module for the Apptainer operator.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Quality of life update to improve how we deploy the Apptainer operator.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

The current documentation we have for Apptainer does not use Terraform, so theoretically this PR does not require a documentation update, but we should update the existing Apptainer documentation to include deploying with Terraform.