### PR TITLE
chore: migrate repo to the canonical org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-** @charmed-hpc/python-reviewers
+** @canonical/hpc-code-reviewers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# Pre-submission checklist
+
+ * [ ] I read and followed the CONTRIBUTING guidelines.
+ * [ ] I have ensured that lint, typecheck, and unit tests complete successfully.
+
+[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)
+
+## Summary of changes
+
+[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)
+
+
+
+#### Related Issues, PRs, and Discussions
+
+[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)
+
+
+
+## Docs
+
+* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.
+
+[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)
+
+Or:
+
+* [ ] I confirm that this pull request requires no changes or additions to documentation.
+
+[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Apptainer operator
 
-[![apptainer charm tests](https://github.com/charmed-hpc/apptainer-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/charmed-hpc/apptainer-operator/actions/workflows/ci.yaml)
-[![Release to `latest/edge` channel on Charmhub](https://github.com/charmed-hpc/apptainer-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/charmed-hpc/apptainer-operator/actions/workflows/release.yaml)
-![GitHub License](https://img.shields.io/github/license/charmed-hpc/apptainer-operator)
+[![apptainer charm tests](https://github.com/canonical/apptainer-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/apptainer-operator/actions/workflows/ci.yaml)
+[![Release to `latest/edge` channel on Charmhub](https://github.com/canonical/apptainer-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/apptainer-operator/actions/workflows/release.yaml)
+![GitHub License](https://img.shields.io/github/license/canonical/apptainer-operator)
 [![Matrix](https://img.shields.io/matrix/ubuntu-hpc%3Amatrix.org?logo=matrix&label=ubuntu-hpc)](https://matrix.to/#/#hpc:ubuntu.com)
 
 A [Juju](https://juju.is) charm for automating the full lifecycle operations of 
@@ -65,8 +65,7 @@ or have any further questions on what you can do with the operator, here are som
 further resources for you to explore:
 
 * [Charmed HPC documentation](https://canonical-charmed-hpc.readthedocs-hosted.com/latest/)
-* [Open an issue](https://github.com/charmed-hpc/apptainer-operator/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
-* [Ask a question on GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
+* [Open an issue](https://github.com/canonical/apptainer-operator/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
 
 ## 🛠️ Development
 
@@ -103,7 +102,6 @@ Here’s some links to help you get started with joining the community:
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Join the conversation on Matrix](https://matrix.to/#/#hpc:ubuntu.com)
 * [Get the latest news on Discourse](https://discourse.ubuntu.com/c/hpc/151)
-* [Ask and answer questions on GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
 
 ## 📋 License
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -26,9 +26,9 @@ description: |
 links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
   issues:
-  - https://github.com/charmed-hpc/apptainer-operator/issues
+  - https://github.com/canonical/apptainer-operator/issues
   source:
-  - https://github.com/charmed-hpc/apptainer-operator
+  - https://github.com/canonical/apptainer-operator
 
 assumes:
   - juju


### PR DESCRIPTION
Migrate all our references to the charmed-hpc org to the canonical org equivalent.